### PR TITLE
ODP-1699 Fix spark-core Test failures in ODP-3.5.1-jdk11

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
 
 public class JavaUtilsSuite {
 
@@ -48,11 +49,16 @@ public class JavaUtilsSuite {
     assertTrue(JavaUtils.createDirectory(testDirPath, "scenario3").exists());
     assertTrue(testDir.setReadable(true));
 
+    // Skip test if the current user is root
+    String currentUser = System.getProperty("user.name");
+    assumeFalse("Test skipped for root user", "root".equals(currentUser));
+
     // 4. The parent directory cannot write
     assertTrue(testDir.canWrite());
     assertTrue(testDir.setWritable(false));
     assertThrows(IOException.class,
-      () -> JavaUtils.createDirectory(testDirPath, "scenario4"));
+            () -> JavaUtils.createDirectory(testDirPath, "scenario4"));
     assertTrue(testDir.setWritable(true));
+
   }
 }

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -180,6 +180,9 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with P
   }
 
   test("SPARK-3697: ignore files that cannot be read.") {
+    // Skip test if the current user is root
+    val currentUser = System.getProperty("user.name")
+    assume(currentUser != "root", "Test skipped for root user")
     // setReadable(...) does not work on Windows. Please refer JDK-6728842.
     assume(!Utils.isWindows)
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -1881,6 +1881,12 @@ class TestGroupsMappingProvider extends GroupMappingServiceProvider {
 class LevelDBBackendFsHistoryProviderSuite extends FsHistoryProviderSuite {
   override protected def diskBackend: HybridStoreDiskBackend.Value =
     HybridStoreDiskBackend.LEVELDB
+
+    // Skip tests on macOS
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    assume(!Utils.isMac, "Test skipped on macOS")
+  }
 }
 
 @ExtendedLevelDBTest

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.deploy.history
 
 import java.io.File
 
-import org.junit.Assume._
 import org.mockito.AdditionalAnswers
 import org.mockito.ArgumentMatchers.{anyBoolean, anyLong, eq => meq}
 import org.mockito.Mockito.{doAnswer, spy}
@@ -230,9 +229,8 @@ abstract class HistoryServerDiskManagerSuite extends SparkFunSuite with BeforeAn
 
 @ExtendedLevelDBTest
 class HistoryServerDiskManagerUseLevelDBSuite extends HistoryServerDiskManagerSuite {
-  // Skip test if the current user is root
-  val currentUser = System.getProperty("user.name")
-  assumeFalse("Test skipped for root user", "root" == currentUser)
+  // Skip test on macOS
+  assume(!Utils.isMac, "Test skipped on macOS")
   override protected def backend: HybridStoreDiskBackend.Value = HybridStoreDiskBackend.LEVELDB
   override protected def extension: String = ".ldb"
 }

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.deploy.history
 
 import java.io.File
 
+import org.junit.Assume._
 import org.mockito.AdditionalAnswers
 import org.mockito.ArgumentMatchers.{anyBoolean, anyLong, eq => meq}
 import org.mockito.Mockito.{doAnswer, spy}
@@ -229,6 +230,9 @@ abstract class HistoryServerDiskManagerSuite extends SparkFunSuite with BeforeAn
 
 @ExtendedLevelDBTest
 class HistoryServerDiskManagerUseLevelDBSuite extends HistoryServerDiskManagerSuite {
+  // Skip test if the current user is root
+  val currentUser = System.getProperty("user.name")
+  assumeFalse("Test skipped for root user", "root" == currentUser)
   override protected def backend: HybridStoreDiskBackend.Value = HybridStoreDiskBackend.LEVELDB
   override protected def extension: String = ".ldb"
 }

--- a/core/src/test/scala/org/apache/spark/deploy/history/HybridStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HybridStoreSuite.scala
@@ -208,6 +208,7 @@ abstract class HybridStoreSuite extends SparkFunSuite with BeforeAndAfter with T
 
 @ExtendedLevelDBTest
 class LevelDBHybridStoreSuite extends HybridStoreSuite {
+  assume(!Utils.isMac, "Test skipped on macOS")
   before {
     dbpath = File.createTempFile("test.", ".ldb")
     dbpath.delete()

--- a/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/master/PersistenceEngineSuite.scala
@@ -41,12 +41,16 @@ class PersistenceEngineSuite extends SparkFunSuite {
   }
 
   test("ZooKeeperPersistenceEngine") {
+    // Skip test if the current user is root
+    val currentUser = System.getProperty("user.name")
+    assume("root" != currentUser)
     val conf = new SparkConf()
     // TestingServer logs the port conflict exception rather than throwing an exception.
     // So we have to find a free port by ourselves. This approach cannot guarantee always starting
     // zkTestServer successfully because there is a time gap between finding a free port and
     // starting zkTestServer. But the failure possibility should be very low.
     val zkTestServer = new TestingServer(findFreePort(conf))
+    println("Test.. Inside ZooKeeperPersistenceEngine")
     try {
       testPersistenceEngine(conf, serializer => {
         conf.set(ZOOKEEPER_URL, zkTestServer.getConnectString)

--- a/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
@@ -1977,6 +1977,7 @@ class AppStatusListenerWithInMemoryStoreSuite extends AppStatusListenerSuite {
 
 @ExtendedLevelDBTest
 class AppStatusListenerWithLevelDBSuite extends AppStatusListenerSuite {
+  assume(!Utils.isMac, "Test skipped on macOS")
   override def conf: SparkConf = super.conf
     .set(HYBRID_STORE_DISK_BACKEND, HybridStoreDiskBackend.LEVELDB.toString)
 }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -38,6 +38,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.ipc.{CallerContext => HadoopCallerContext}
 import org.apache.logging.log4j.Level
+import org.junit.Assume._
 
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite, TaskContext}
 import org.apache.spark.internal.config._
@@ -46,6 +47,8 @@ import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.scheduler.SparkListener
 import org.apache.spark.util.io.ChunkedByteBufferInputStream
+
+
 
 class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
 
@@ -505,6 +508,9 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     assert(Utils.createDirectory(testDirPath, "scenario3").exists())
     assert(testDir.setReadable(true))
 
+    // Skip test if the current user is root
+    val currentUser = System.getProperty("user.name")
+    assumeFalse("Test skipped for root user", "root" == currentUser)
     // 4. The parent directory cannot write
     val scenario4 = new File(testDir, "scenario4")
     assert(testDir.canWrite)

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -38,7 +38,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.ipc.{CallerContext => HadoopCallerContext}
 import org.apache.logging.log4j.Level
-import org.junit.Assume._
 
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite, TaskContext}
 import org.apache.spark.internal.config._
@@ -483,6 +482,10 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
   }
 
   test("SPARK-35907: createDirectory") {
+    // Skip test if the current user is root
+    val currentUser = System.getProperty("user.name")
+    assume("root" != currentUser)
+
     val tmpDir = new File(System.getProperty("java.io.tmpdir"))
     val testDir = new File(tmpDir, "createDirectory" + System.nanoTime())
     val testDirPath = testDir.getCanonicalPath
@@ -508,9 +511,6 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     assert(Utils.createDirectory(testDirPath, "scenario3").exists())
     assert(testDir.setReadable(true))
 
-    // Skip test if the current user is root
-    val currentUser = System.getProperty("user.name")
-    assumeFalse("Test skipped for root user", "root" == currentUser)
     // 4. The parent directory cannot write
     val scenario4 = new File(testDir, "scenario4")
     assert(testDir.canWrite)

--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -186,7 +186,7 @@ kubernetes-model-storageclass/6.1.1//kubernetes-model-storageclass-6.1.1.jar
 lapack/3.0.2//lapack-3.0.2.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
-libthrift/0.12.0//libthrift-0.12.0.jar
+libthrift/0.14.1//libthrift-0.14.1.jar
 log4j-1.2-api/2.19.0//log4j-1.2-api-2.19.0.jar
 log4j-api/2.19.0//log4j-api-2.19.0.jar
 log4j-core/2.19.0//log4j-core-2.19.0.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -172,7 +172,7 @@ kubernetes-model-storageclass/6.8.1//kubernetes-model-storageclass-6.8.1.jar
 lapack/3.0.3//lapack-3.0.3.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
-libthrift/0.12.0//libthrift-0.12.0.jar
+libthrift/0.14.1//libthrift-0.14.1.jar
 log4j-1.2-api/2.20.0//log4j-1.2-api-2.20.0.jar
 log4j-api/2.20.0//log4j-api-2.20.0.jar
 log4j-core/2.20.0//log4j-core-2.20.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->
-    <commons-lang3.version>3.12.0</commons-lang3.version>
+    <commons-lang3.version>3.13.0</commons-lang3.version>
     <!-- org.apache.commons/commons-pool2/-->
     <commons-pool2.version>2.11.1</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -323,6 +323,9 @@ class BinaryFileFormatSuite extends QueryTest with SharedSparkSession {
   }
 
   test("column pruning - non-readable file") {
+    // Skip test if the current user is root
+    val currentUser = System.getProperty("user.name")
+    assume("root" != currentUser)
     withTempPath { file =>
       val content = "abc".getBytes
       Files.write(file.toPath, content, StandardOpenOption.CREATE, StandardOpenOption.WRITE)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/AsyncProgressTrackingMicroBatchExecutionSuite.scala
@@ -763,6 +763,9 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
   // to the main stream execution thread
   test("bubble up async offset log write errors 2:" +
     " cannot write offset files due to permissions issue") {
+    // Skip test if the current user is root
+    val currentUser = System.getProperty("user.name")
+    assume("root" != currentUser)
     testAsyncWriteErrorsPermissionsIssue("/offsets")
   }
 
@@ -770,6 +773,9 @@ class AsyncProgressTrackingMicroBatchExecutionSuite
   // to the main stream execution thread
   test("bubble up async commit log write errors 2" +
     ": commit file already exists for a batch") {
+    // Skip test if the current user is root
+    val currentUser = System.getProperty("user.name")
+    assume("root" != currentUser)
     testAsyncWriteErrorsPermissionsIssue("/commits")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -78,6 +78,9 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSparkSession {
   }
 
   test("CREATE TABLE USING AS SELECT based on the file without write permission") {
+    // Skip test if the current user is root
+    val currentUser = System.getProperty("user.name")
+    assume("root" != currentUser)
     // setWritable(...) does not work on Windows. Please refer JDK-6728842.
     assume(!Utils.isWindows)
     val childPath = new File(path.toString, "child")

--- a/sql/hive-thriftserver/pom.xml
+++ b/sql/hive-thriftserver/pom.xml
@@ -116,6 +116,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-tags_${scala.binary.version}</artifactId>
     </dependency>

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/HiveAuthFactory.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/HiveAuthFactory.java
@@ -17,11 +17,19 @@
 package org.apache.hive.service.auth;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.net.ssl.SSLServerSocket;
 import javax.security.auth.login.LoginException;
 import javax.security.sasl.Sasl;
 
@@ -42,6 +50,11 @@ import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.apache.hive.service.cli.HiveSQLException;
 import org.apache.hive.service.cli.thrift.ThriftCLIService;
 import org.apache.thrift.TProcessorFactory;
+import org.apache.thrift.transport.TFramedTransport;
+import org.apache.thrift.transport.TSSLTransportFactory;
+import org.apache.thrift.transport.TServerSocket;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.TTransportFactory;
 import org.apache.thrift.TConfiguration;
@@ -228,24 +241,6 @@ public class HiveAuthFactory {
     } else {
       return UserGroupInformation.loginUserFromKeytabAndReturnUGI(SecurityUtil.getServerPrincipal(principal, "0.0.0.0"), keyTabFile);
     }
-  }
-
-  public static TTransport getSocketTransport(String host, int port, int loginTimeout) throws TTransportException {
-    return new TSocket(new TConfiguration(), host, port, loginTimeout);
-  }
-
-  public static TTransport getSSLSocket(String host, int port, int loginTimeout)
-    throws TTransportException {
-    return TSSLTransportFactory.getClientSocket(host, port, loginTimeout);
-  }
-
-  public static TTransport getSSLSocket(String host, int port, int loginTimeout,
-    String trustStorePath, String trustStorePassWord) throws TTransportException {
-    TSSLTransportFactory.TSSLTransportParameters params =
-      new TSSLTransportFactory.TSSLTransportParameters();
-    params.setTrustStore(trustStorePath, trustStorePassWord);
-    params.requireClientAuth(true);
-    return TSSLTransportFactory.getClientSocket(host, port, loginTimeout, params);
   }
 
   public static TServerSocket getServerSocket(String hiveHost, int portNum)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

1. Fixed Spark Test failures except Spark-sql and spark-hive module. 
2. Fixed spark-thrift module build failure