### PR TITLE
ODP-2118: Hudi, Delta-lake, Iceberg version upgrade for open table clients.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -81,12 +81,12 @@
     </dependency>
     <dependency>
       <groupId>io.delta</groupId>
-      <artifactId>delta-core_${scala.binary.version}</artifactId>
+      <artifactId>delta-spark_2.13</artifactId>
       <version>${deltalake.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hudi</groupId>
-      <artifactId>hudi-spark3.3-bundle_${scala.binary.version}</artifactId>
+      <artifactId>hudi-spark3.5-bundle_${scala.binary.version}</artifactId>
       <version>${hudi.version}</version>
     </dependency>
     <!--  Commenting out to avoid Build error "Found Banned Dependency: org.apache.iceberg:iceberg-spark-runtime-3.3_2.12:jar:1.5.0"

--- a/pom.xml
+++ b/pom.xml
@@ -160,9 +160,9 @@
     <chill.version>0.10.0</chill.version>
     <ivy.version>2.5.2</ivy.version>
     <oro.version>2.0.8</oro.version>
-    <deltalake.version>2.3.0</deltalake.version>
-    <hudi.version>0.14.2</hudi.version>
-    <iceberg.version>1.5.0</iceberg.version>
+    <deltalake.version>3.2.0</deltalake.version>
+    <hudi.version>0.15.0</hudi.version>
+    <iceberg.version>1.6.0</iceberg.version>
     <!--
     If you changes codahale.metrics.version, you also need to change
     the link to metrics.dropwizard.io in docs/monitoring.md.

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <ivy.version>2.5.2</ivy.version>
     <oro.version>2.0.8</oro.version>
     <deltalake.version>3.2.0</deltalake.version>
-    <hudi.version>0.15.0</hudi.version>
+    <hudi.version>0.15.1</hudi.version>
     <iceberg.version>1.6.0</iceberg.version>
     <!--
     If you changes codahale.metrics.version, you also need to change


### PR DESCRIPTION

### Description
ODP-2118: Hudi, Delta-lake, Iceberg version upgrade for open table.

### How was this patch tested?
This patch was tested in local environment.