### PR TITLE
ODP-6700 : Build Spark distribution using Maven install instead of package

### DIFF
--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -180,7 +180,7 @@ else
   # Store the command as an array because $MVN variable might have spaces in it.
   # Normal quoting tricks don't work.
   # See: http://mywiki.wooledge.org/BashFAQ/050
-  BUILD_COMMAND=("$MVN" clean package \
+  BUILD_COMMAND=("$MVN" clean install \
       -DskipTests \
       -Dmaven.javadoc.skip=true \
       -Dmaven.scaladoc.skip=true \


### PR DESCRIPTION
This patch was tested locally.