### PR TITLE
ODP-6827 : correct spark version in R/pkg/DESCRIPTION

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SparkR
 Type: Package
-Version: 3.3.3
+Version: 3.3.3.3.3.6.5-SNAPSHOT
 Title: R Front End for 'Apache Spark'
 Description: Provides an R Front end for 'Apache Spark' <https://spark.apache.org>.
 Authors@R:


### PR DESCRIPTION
This patch was tested locally.