### PR TITLE
ODP-6842 : Fix snapshot repository URL typo in Maven distribution management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <snapshotRepository>
       <id>nexus-snapshots</id>
       <name>Snapshot</name>
-      <url>https://repo1.acceldata.dev/repository/odp-stagnig-snapshot/</url>
+      <url>https://repo1.acceldata.dev/repository/odp-staging-snapshot/</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
This patch was tested locally.