### PR TITLE
OSV-19714 - CVE - Increasing netty version to fix CVE-2026-42587

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
     <commons-cli.version>1.5.0</commons-cli.version>
     <bouncycastle.version>1.77</bouncycastle.version>
     <tink.version>1.9.0</tink.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.


### PR DESCRIPTION
Automated CVE fix.

- Library : io.netty_netty-codec, io.netty_netty-codec-http, io.netty_netty-codec-http2
- Version : -> 4.1.135.Final
- Tickets : OSV-19714, OSV-19712, OSV-19711, OSV-19710, OSV-19709, OSV-19708, OSV-19707, OSV-19706