### PR TITLE
OSV-19741 - CVE - Increasing log4j2 version to fix CVE-2026-34479

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.5</asm.version>
     <slf4j.version>2.0.7</slf4j.version>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.25.4</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.2.3.3.2.3.7-2</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
Automated CVE fix.

- Library : org.apache.logging.log4j_log4j-1.2-api, org.apache.logging.log4j_log4j-core
- Version : -> 2.25.4
- Tickets : OSV-19741, OSV-19740, OSV-19739, OSV-19738, OSV-19737, OSV-19716