### PR TITLE
OSV-19743 - CVE - Increasing aircompressor version to fix CVE-2025-67721

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2658,7 +2658,7 @@
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.orc</groupId>


### PR DESCRIPTION
Automated CVE fix.

- Library : io.airlift_aircompressor
- Version : -> 2.0.3
- Tickets : OSV-19743