### PR TITLE
OSV-20833 - CVE - Increasing jackson version to fix GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,8 +195,8 @@
     <scalafmt.validateOnly>true</scalafmt.validateOnly>
     <scalafmt.changedOnly>true</scalafmt.changedOnly>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-    <fasterxml.jackson.version>2.17.2</fasterxml.jackson.version>
-    <fasterxml.jackson.databind.version>2.17.2</fasterxml.jackson.databind.version>
+    <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.18.6</fasterxml.jackson.databind.version>
     <snappy.version>1.1.10.4</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.16.0</commons-codec.version>


### PR DESCRIPTION
- Library : com.fasterxml.jackson.core_jackson-core
- Version : -> 2.18.6
- Tickets : OSV-20833