### PR TITLE
OSV-20854 - CVE - Increasing netty version to fix CVE-2026-42583

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
     <commons-cli.version>1.5.0</commons-cli.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <tink.version>1.9.0</tink.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.


### PR DESCRIPTION
- Library : io.netty_netty-codec, io.netty_netty-codec-http, io.netty_netty-codec-http2
- Version : -> 4.1.135.Final
- Tickets : OSV-20854, OSV-20845, OSV-20840, OSV-20839, OSV-20838, OSV-20837, OSV-20836, OSV-20835