### PR TITLE
OSV-20820 - CVE - Increasing jackson version to fix GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,8 +189,8 @@
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-    <fasterxml.jackson.version>2.17.2</fasterxml.jackson.version>
-    <fasterxml.jackson.databind.version>2.17.2</fasterxml.jackson.databind.version>
+    <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.18.6</fasterxml.jackson.databind.version>
     <snappy.version>1.1.10.4</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <netlib.ludovic.dev.version>2.2.1</netlib.ludovic.dev.version>


### PR DESCRIPTION
- Library : com.fasterxml.jackson.core_jackson-core
- Version : -> 2.18.6
- Tickets : OSV-20820