### PR TITLE
OSV-20763 - CVE - Increasing netty version to fix CVE-2023-34462

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
     <commons-cli.version>1.5.0</commons-cli.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <tink.version>1.9.0</tink.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.


### PR DESCRIPTION
- Library : io.netty_netty-codec, io.netty_netty-common, io.netty_netty-handler
- Version : -> 4.1.135.Final
- Tickets : OSV-20763, OSV-20752, OSV-20751, OSV-20756, OSV-20755