### PR TITLE
OSV-20824 - CVE - Increasing log4j2 version to fix CVE-2026-34479

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <slf4j.version>1.7.32</slf4j.version>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.25.4</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.2.3.3.2.3.7-2</hadoop.version>
     <!-- SPARK-42188: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
- Library : org.apache.logging.log4j_log4j-1.2-api, org.apache.logging.log4j_log4j-core
- Version : -> 2.25.4
- Tickets : OSV-20824, OSV-20809, OSV-20808, OSV-20807, OSV-20806, OSV-20805