### PR TITLE
OSV-20772 - CVE - Increasing commons-compress version to fix CVE-2024-26308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
     <netlib.java.version>1.1.2</netlib.java.version>
     <netlib.ludovic.dev.version>2.2.1</netlib.ludovic.dev.version>
     <commons-codec.version>1.15</commons-codec.version>
-    <commons-compress.version>1.21</commons-compress.version>
+    <commons-compress.version>1.26.1</commons-compress.version>
     <commons-io.version>2.11.0</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>


### PR DESCRIPTION
- Library : org.apache.commons_commons-compress
- Version : -> 1.26.1
- Tickets : OSV-20772, OSV-20771