### PR TITLE
OSV-20748 - CVE - Increasing commons-io version to fix CVE-2024-47554

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <netlib.ludovic.dev.version>2.2.1</netlib.ludovic.dev.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-compress.version>1.21</commons-compress.version>
-    <commons-io.version>2.11.0</commons-io.version>
+    <commons-io.version>2.16.1</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->


### PR DESCRIPTION
- Library : commons-io_commons-io
- Version : -> 2.16.1
- Tickets : OSV-20748