### PR TITLE
OSV-20825 - CVE - Increasing okio version to fix CVE-2023-3635

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>1.17.6</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-tags_${scala.binary.version}</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
- Library : com.squareup.okio_okio
- Version : -> 1.17.6
- Tickets : OSV-20825