### PR TITLE
OSV-20750 - CVE - Upgrade Scala to 2.12.18 (silencer 1.7.13) to enable commons-lang3 3.18.0 fix for CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.collections4.version>4.4</commons.collections4.version>
-    <scala.version>2.12.15</scala.version>
+    <scala.version>2.12.18</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
     <!--
@@ -200,7 +200,7 @@
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->
-    <commons-lang3.version>3.13.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <!-- org.apache.commons/commons-pool2/-->
     <commons-pool2.version>2.11.1</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>
@@ -2916,7 +2916,7 @@
               <compilerPlugin>
                 <groupId>com.github.ghik</groupId>
                 <artifactId>silencer-plugin_${scala.version}</artifactId>
-                <version>1.7.6</version>
+                <version>1.7.13</version>
               </compilerPlugin>
             </compilerPlugins>
           </configuration>
@@ -3583,7 +3583,7 @@
          SPARK-34774 Add this property to ensure change-scala-version.sh can replace the public `scala.version`
          property correctly.
         -->
-        <scala.version>2.12.15</scala.version>
+        <scala.version>2.12.18</scala.version>
       </properties>
       <build>
         <pluginManagement>


### PR DESCRIPTION
- Library : org.apache.commons_commons-lang3
- Version : -> 3.18.0
- Tickets : OSV-20750