### PR TITLE
OSV-23559 - CVE - Bumped-up Jackson to 2.18.6 to address PRISMA-2023-0067

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,8 +199,8 @@
     <scalafmt.validateOnly>true</scalafmt.validateOnly>
     <scalafmt.changedOnly>true</scalafmt.changedOnly>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-    <fasterxml.jackson.version>2.17.2</fasterxml.jackson.version>
-    <fasterxml.jackson.databind.version>2.17.2</fasterxml.jackson.databind.version>
+    <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.18.6</fasterxml.jackson.databind.version>
     <snappy.version>1.1.10.5</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.16.1</commons-codec.version>


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-23559, OSV-23560, OSV-23561, OSV-23579, OSV-23584, OSV-23586, OSV-23590