### PR TITLE
OSV-23909 - CVE - Bumped-up Jackson to 2.18.6 to address PRISMA-2023-0067

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,8 +190,8 @@
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-    <fasterxml.jackson.version>2.17.2</fasterxml.jackson.version>
-    <fasterxml.jackson.databind.version>2.17.2</fasterxml.jackson.databind.version>
+    <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
+    <fasterxml.jackson.databind.version>2.18.6</fasterxml.jackson.databind.version>
     <snappy.version>1.1.10.4</snappy.version>
     <netlib.java.version>1.1.2</netlib.java.version>
     <netlib.ludovic.dev.version>2.2.1</netlib.ludovic.dev.version>


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-23909, OSV-23910, OSV-23911, OSV-23934, OSV-23946, OSV-23947, OSV-23948, OSV-23949, OSV-23951, OSV-23952, OSV-23953, OSV-23955, OSV-23956, OSV-23957, OSV-23958, OSV-23962