### PR TITLE
OSV-23633 - CVE - Bumped-up Jackson to 2.21.1 to address GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
     <scalafmt.validateOnly>true</scalafmt.validateOnly>
     <scalafmt.changedOnly>true</scalafmt.changedOnly>
     <!-- Should be consistent with SparkBuild.scala and docs -->
-    <fasterxml.jackson.version>2.20.0</fasterxml.jackson.version>
+    <fasterxml.jackson.version>2.21.1</fasterxml.jackson.version>
     <ws.xmlschema.version>2.3.1</ws.xmlschema.version>
     <snappy.version>1.1.10.8</snappy.version>
     <netlib.ludovic.dev.version>3.0.4</netlib.ludovic.dev.version>


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.21.1
- Tickets : OSV-23633, OSV-23651, OSV-23655, OSV-23656, OSV-23657, OSV-23682, OSV-23686