### PR TITLE
OSV-23994 - CVE - Bumped-up Log4j to 2.25.4 to address CVE-2026-34478

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <slf4j.version>1.7.32</slf4j.version>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.25.4</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.6.${odp.release.version}</hadoop.version>
     <!-- SPARK-42188: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
- Library : Log4j
- Version : -> 2.25.4
- Tickets : OSV-23994, OSV-23995, OSV-23996, OSV-23997, OSV-23998, OSV-24011