### PR TITLE
OSV-23646 - CVE - Bumped-up Log4j to 2.25.4 to address CVE-2026-34479

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.9</asm.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.25.4</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.6.${odp.release.version}</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
- Library : Log4j
- Version : -> 2.25.4
- Tickets : OSV-23646, OSV-23659, OSV-23660, OSV-23661, OSV-23662, OSV-23663, OSV-23699