### PR TITLE
OSV-23562 - CVE - Bumped-up Netty to 4.1.135.Final to address CVE-2026-42583

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
     <commons-cli.version>1.5.0</commons-cli.version>
     <bouncycastle.version>1.77</bouncycastle.version>
     <tink.version>1.9.0</tink.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.


### PR DESCRIPTION
- Library : Netty
- Version : -> 4.1.135.Final
- Tickets : OSV-23562, OSV-23589, OSV-23606, OSV-23607, OSV-23608, OSV-23609, OSV-23610, OSV-23611