### PR TITLE
OSV-23912 - CVE - Bumped-up Netty to 4.1.135.Final to address CVE-2025-58057

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
     <commons-cli.version>1.5.0</commons-cli.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <tink.version>1.9.0</tink.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.


### PR DESCRIPTION
- Library : Netty
- Version : -> 4.1.135.Final
- Tickets : OSV-23912, OSV-23913, OSV-23964, OSV-24002, OSV-24003