### PR TITLE
OSV-24014 - CVE - Bumped-up Netty to 4.1.135.Final to address CVE-2026-42583

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
     <commons-cli.version>1.5.0</commons-cli.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <tink.version>1.9.0</tink.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.


### PR DESCRIPTION
- Library : Netty
- Version : -> 4.1.135.Final
- Tickets : OSV-24014, OSV-24017, OSV-24018, OSV-24019, OSV-24020, OSV-24021, OSV-24022, OSV-24024