### PR TITLE
OSV-23629 - CVE - Bumped-up Netty to 4.2.13.Final to address CVE-2026-42579

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
     <bouncycastle.version>1.82</bouncycastle.version>
     <tink.version>1.16.0</tink.version>
     <datasketches.version>6.2.0</datasketches.version>
-    <netty.version>4.2.7.Final</netty.version>
+    <netty.version>4.2.13.Final</netty.version>
     <netty-tcnative.version>2.0.74.Final</netty-tcnative.version>
     <icu4j.version>77.1</icu4j.version>
     <junit.version>6.0.0</junit.version>


### PR DESCRIPTION
- Library : Netty
- Version : -> 4.2.13.Final
- Tickets : OSV-23629, OSV-23630, OSV-23664, OSV-23666, OSV-23667, OSV-23668, OSV-23669, OSV-23670, OSV-23671, OSV-23672, OSV-23673, OSV-23674, OSV-23675, OSV-23680