### PR TITLE
OSV-24016 - CVE - Bumped-up commons-lang3 to 3.18.0 to address CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->
-    <commons-lang3.version>3.13.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <!-- org.apache.commons/commons-pool2/-->
     <commons-pool2.version>2.11.1</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>


### PR DESCRIPTION
- Library : commons-lang3
- Version : -> 3.18.0
- Tickets : OSV-24016
- Component: spark3_3_5_1 (nightly/ODP-3.5.1.3.3.6.5)