### PR TITLE
OSV-23930 - CVE - Bumped-up aircompressor to 2.0.3 to address CVE-2025-67721

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2542,7 +2542,7 @@
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.orc</groupId>


### PR DESCRIPTION
- Library : aircompressor
- Version : -> 2.0.3
- Tickets : OSV-23930
- Component: spark3_3_3_3 (nightly/ODP-3.3.3.3.3.6.5)