### PR TITLE
OSV-24000 - CVE - Bumped-up commons-compress to 1.26.1 to address CVE-2024-26308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <netlib.java.version>1.1.2</netlib.java.version>
     <netlib.ludovic.dev.version>2.2.1</netlib.ludovic.dev.version>
     <commons-codec.version>1.15</commons-codec.version>
-    <commons-compress.version>1.21</commons-compress.version>
+    <commons-compress.version>1.26.1</commons-compress.version>
     <commons-io.version>2.11.0</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>


### PR DESCRIPTION
- Library : commons-compress
- Version : -> 1.26.1
- Tickets : OSV-24000, OSV-24001
- Component: spark3_3_3_3 (nightly/ODP-3.3.3.3.3.6.5)