### PR TITLE
OSV-23927 - CVE - Bumped-up okio to 1.17.6 to address CVE-2023-3635

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2771,7 +2771,13 @@
         <artifactId>arpack</artifactId>
         <version>${netlib.ludovic.dev.version}</version>
       </dependency>
-    </dependencies>
+    
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>1.17.6</version>
+      </dependency>
+</dependencies>
   </dependencyManagement>
 
   <build>


### PR DESCRIPTION
- Library : okio
- Version : -> 1.17.6
- Tickets : OSV-23927
- Component: spark3_3_3_3 (nightly/ODP-3.3.3.3.3.6.5)