### PR TITLE
ODP-6259 | [SQL] Enable TRUNCATE TABLE on external tables via config flag

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -4448,7 +4448,7 @@
   },
   "_LEGACY_ERROR_TEMP_1266" : {
     "message" : [
-      "Operation not allowed: TRUNCATE TABLE on external tables: <tableIdentWithDB>."
+      "Operation not allowed: TRUNCATE TABLE on external tables: <tableIdentWithDB>. Set spark.sql.truncate.allowExternalTables=true to enable this."
     ]
   },
   "_LEGACY_ERROR_TEMP_1267" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3655,6 +3655,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val TRUNCATE_TABLE_ALLOW_EXTERNAL =
+    buildConf("spark.sql.truncate.allowExternalTables")
+      .doc("When set to true, TRUNCATE TABLE is permitted on external tables. " +
+        "This permanently deletes all data at the external storage location. " +
+        "Use with caution: data cannot be recovered after truncation.")
+      .version("3.5.5")
+      .booleanConf
+      .createWithDefault(false)
+
   val NAME_NON_STRUCT_GROUPING_KEY_AS_VALUE =
     buildConf("spark.sql.legacy.dataset.nameNonStructGroupingKeyAsValue")
       .internal()
@@ -5182,6 +5191,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def truncateTableIgnorePermissionAcl: Boolean =
     getConf(SQLConf.TRUNCATE_TABLE_IGNORE_PERMISSION_ACL)
+
+  def truncateTableAllowExternal: Boolean =
+    getConf(SQLConf.TRUNCATE_TABLE_ALLOW_EXTERNAL)
 
   def nameNonStructGroupingKeyAsValue: Boolean =
     getConf(SQLConf.NAME_NON_STRUCT_GROUPING_KEY_AS_VALUE)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -461,7 +461,9 @@ case class TruncateTableCommand(
     val table = catalog.getTableMetadata(tableName)
     val tableIdentWithDB = table.identifier.quotedString
 
-    if (table.tableType == CatalogTableType.EXTERNAL) {
+    // ODP-6259: external tables stay blocked by default; spark.sql.truncate.allowExternalTables
+    // opts in to truncating them, which permanently deletes the data at the external location.
+    if (table.tableType == CatalogTableType.EXTERNAL && !conf.truncateTableAllowExternal) {
       throw QueryCompilationErrors.truncateTableOnExternalTablesError(tableIdentWithDB)
     }
     if (table.partitionColumnNames.isEmpty && partitionSpec.isDefined) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/TruncateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/TruncateTableSuite.scala
@@ -207,4 +207,24 @@ class TruncateTableSuite extends TruncateTableSuiteBase with CommandSuiteBase {
       }
     }
   }
+
+  test("ODP-6259: truncation of external tables is allowed when the config is set") {
+    import testImplicits._
+    withTempPath { tempDir =>
+      withNamespaceAndTable("ns", "tbl") { t =>
+        (("a", "b") :: Nil).toDF().write.parquet(tempDir.getCanonicalPath)
+        sql(s"CREATE TABLE $t $defaultUsing LOCATION '${tempDir.toURI}'")
+        assert(spark.table(t).collect().nonEmpty,
+          "bad test; table was empty to begin with")
+        withSQLConf(SQLConf.TRUNCATE_TABLE_ALLOW_EXTERNAL.key -> "true") {
+          sql(s"TRUNCATE TABLE $t")
+          assert(spark.table(t).collect().isEmpty)
+        }
+        // the external location itself must survive truncation, only its contents go
+        val path = new Path(tempDir.getCanonicalPath)
+        val fs = path.getFileSystem(spark.sessionState.newHadoopConf())
+        assert(fs.exists(path), "table location directory must still exist after truncation")
+      }
+    }
+  }
 }


### PR DESCRIPTION
…flag

Port of acceldata-io/spark#29 ("ODP-6259 Enable Truncate for Spark2") to Spark 3.5.

- Add `spark.sql.truncate.allowExternalTables` (default: false) to gate truncation of external tables rather than hard-removing the guard in TruncateTableCommand.
- Point the existing _LEGACY_ERROR_TEMP_1266 message at the new config so the default failure tells the user how to opt in. Spark 3 raises this through QueryCompilationErrors/error classes, so the hint belongs in error-classes.json rather than an inline AnalysisException string.
- Add a v1 TruncateTableSuite test covering the opt-in path, and assert the external location directory itself survives truncation.

Differences from the Spark 2 change, all because 3.5 already handles these: the VIEW guard is gone from TruncateTableCommand (visitTruncateTable builds an UnresolvedTable, so the analyzer raises expectTableNotViewError first); the guard for TRUNCATE TABLE ... PARTITION on non-partitioned tables is already present; and the truncate tests moved out of DDLSuite into execution/command/v1/TruncateTableSuite.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
